### PR TITLE
Add a lock reason with "resolved"

### DIFF
--- a/src/lock.js
+++ b/src/lock.js
@@ -28,7 +28,11 @@ module.exports = class Lock {
       await this.context.github.issues.lock({
         owner,
         repo,
-        number: issue.number
+        number: issue.number,
+        lock_reason: 'resolved',
+        headers: {
+          accept: 'application/vnd.github.sailor-v-preview+json'
+        }
       });
     }
   }


### PR DESCRIPTION
Ref https://github.com/babel/babel/pull/7839#discussion_r185066696

For the preview, I looked at https://github.com/octokit/rest.js#api-previews and you can already just pass a header (thanks @gr2m)

![image](https://user-images.githubusercontent.com/588473/39453708-06863ff8-4c8c-11e8-8e02-caa17a030b1e.png)

> When locking an issue via the issues API, you can now provide an optional reason that will be visible to anyone who views the issue. Valid lock reasons are "off-topic", "too heated", "resolved", and "spam". Providing a lock reason can help make it clearer to contributors why an issue was locked, and what kinds of behavior may result in issues being locked in the future. 

`resolved` seems to make the most since here so I just hardcoded it. Although maybe we can suggest a new one for this use-case. Feel free to modify this PR if needed