### PR TITLE
Add support for skipping issues created before a given timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ The file can be empty, or it can override any of these default settings:
 # Number of days of inactivity before a closed issue or pull request is locked
 daysUntilLock: 365
 
+# Skip issues and pull requests created before a given timestamp. Timestamp must
+# follow ISO 8601 (`YYYY-MM-DD`). Set to `false` to disable.
+skipCreatedBefore: false
+
 # Issues and pull requests with these labels will not be locked. Set to `[]` to disable
 exemptLabels: []
 

--- a/assets/app-description.md
+++ b/assets/app-description.md
@@ -18,6 +18,10 @@ Create `.github/lock.yml` in the default branch to enable the app. The file can 
 # Number of days of inactivity before a closed issue or pull request is locked
 daysUntilLock: 365
 
+# Skip issues and pull requests created before a given timestamp. Timestamp must
+# follow ISO 8601 (`YYYY-MM-DD`). Set to `false` to disable.
+skipCreatedBefore: false
+
 # Issues and pull requests with these labels will not be locked. Set to `[]` to disable
 exemptLabels: []
 

--- a/src/lock.js
+++ b/src/lock.js
@@ -62,6 +62,7 @@ module.exports = class Lock {
     const {owner, repo} = this.context.repo();
     const daysUntilLock = this.getConfigValue(type, 'daysUntilLock');
     const exemptLabels = this.getConfigValue(type, 'exemptLabels');
+    const skipCreatedBeforeTimestamp = this.getConfigValue(type, 'skipCreatedBefore');
 
     const timestamp = this.getUpdatedTimestamp(daysUntilLock);
 
@@ -76,6 +77,10 @@ module.exports = class Lock {
       query += ' is:issue';
     } else {
       query += ' is:pr';
+    }
+
+    if (skipCreatedBeforeTimestamp) {
+      query += ` created:>${skipCreatedBeforeTimestamp}`;
     }
 
     this.log.info({repo: {owner, repo}}, `Searching ${type}`);

--- a/src/schema.js
+++ b/src/schema.js
@@ -7,6 +7,13 @@ const fields = {
       'Number of days of inactivity before a closed issue or pull request is locked'
     ),
 
+  skipCreatedBefore: Joi.alternatives()
+    .try(Joi.string(), Joi.boolean().only(false))
+    .description(
+      'Skip issues and pull requests created before a given timestamp. Timestamp' +
+      'must follow ISO 8601 (`YYYY-MM-DD`). Set to `false` to disable.'
+    ),
+
   exemptLabels: Joi.array()
     .single()
     .items(Joi.string())
@@ -31,6 +38,7 @@ const fields = {
 
 const schema = Joi.object().keys({
   daysUntilLock: fields.daysUntilLock.default(365),
+  skipCreatedBefore: fields.skipCreatedBefore.default(false),
   exemptLabels: fields.exemptLabels.default([]),
   lockLabel: fields.lockLabel.default(false),
   lockComment: fields.lockComment.default(


### PR DESCRIPTION
This PR introduces a `skipCreatedBefore` parameter to allow the bot to ignore issues/PRs created before a given timestamp. This is useful for people who want to add the bot to existing repos with lots of old issues without having the bot touch all of them (an example is a repo with 20k closed issues).