### PR TITLE
Add support for nesting the lock-threads config below a lockThreads property in a bots yml config file

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,12 @@ module.exports = async robot => {
       if (!repoConfig) {
         repoConfig = {perform: false};
       }
+      if (!repoConfig || !repoConfig.lockThreads) {
+        repoConfig = {perform: false};
+      }
+      if (repoConfig.lockThreads) {
+        repoConfig = repoConfig.lockThreads;
+      }
       const {error, value} = schema.validate(repoConfig);
       if (error) {
         throw error;


### PR DESCRIPTION
This will allow for downstream users of the lockThreads bot place the lock-threads configuration in its own section of their own config file.

Both of the following would be valid and equivilent for the lock-threads bot:
```yml
daysUntilLock: 30

exemptLabels: ['my label']

lockLabel: 'outdated'
```

```yml
lockThreads:

  daysUntilLock: 30

  exemptLabels: ['my label']

  lockLabel: 'outdated'
```