### PR TITLE
Lower daysUntilLock minimum value to 0

### DIFF
--- a/src/schema.js
+++ b/src/schema.js
@@ -2,7 +2,7 @@ const Joi = require('joi');
 
 const fields = {
   daysUntilLock: Joi.number()
-    .min(1)
+    .min(0)
     .description(
       'Number of days of inactivity before a closed issue or pull request is locked'
     ),


### PR DESCRIPTION
Hi! I would like to use lock bot to immediately lock issues/pull requests: https://github.com/prism-break/prism-break/blob/cb9b109973a385e17ad8b24ba9f46d57fcbad732/.github/lock.yml

Unfortunately, that config results in the following error: https://github.com/prism-break/prism-break/issues/2029

This pull request lowers minimum value of `daysUntiLock` to 0. [`getUpdatedTimestamp`](https://github.com/dessant/lock-threads/blob/ace8c2d9ab62922bc899025d12f67e7d51706848/src/lock.js#L100-L104) function works with `0` as an argument.