### PR TITLE
Update dependancy to remove const error

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@actions/core": "^1.2.2",
-    "@actions/github": "^2.1.0",
+    "@actions/github": "^2.2.0",
     "@hapi/joi": "^17.1.0",
     "decamelize": "^4.0.0"
   },


### PR DESCRIPTION
This fixes the octokit error caused by the Toolkit GitHub action.