### PR TITLE
Add support for only including specified labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ All parameters are optional, except `github-token`.
   - Do not lock issues created before a given timestamp,
     value must follow ISO 8601
   - Optional, defaults to `''`
+- **`issue-include-labels`**
+  - Only lock issues with these labels, value must be
+    a comma separated list of labels or `''` which means all closed issues
+  - Optional, defaults to `''`
 - **`issue-exclude-labels`**
   - Do not lock issues with these labels, value must be
     a comma separated list of labels or `''`
@@ -57,6 +61,10 @@ All parameters are optional, except `github-token`.
 - **`pr-exclude-created-before`**
   - Do not lock pull requests created before a given timestamp,
     value must follow ISO 8601
+  - Optional, defaults to `''`
+- **`pr-include-labels`**
+  - Only lock pull requests with these labels, value must
+    be a comma separated list of labels or `''` which means all closed pull requests
   - Optional, defaults to `''`
 - **`pr-exclude-labels`**
   - Do not lock pull requests with these labels, value must
@@ -142,12 +150,14 @@ jobs:
           github-token: ${{ github.token }}
           issue-lock-inactive-days: '365'
           issue-exclude-created-before: ''
+          issue-include-labels: ''
           issue-exclude-labels: ''
           issue-lock-labels: ''
           issue-lock-comment: ''
           issue-lock-reason: 'resolved'
           pr-lock-inactive-days: '365'
           pr-exclude-created-before: ''
+          pr-include-labels: ''
           pr-exclude-labels: ''
           pr-lock-labels: ''
           pr-lock-comment: ''

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,9 @@ inputs:
   issue-exclude-created-before:
     description: 'Do not lock issues created before a given timestamp, value must follow ISO 8601'
     default: ''
+  issue-include-labels:
+    description: 'Only lock issues with these labels, value must be a comma separated list of labels'
+    default: ''
   issue-exclude-labels:
     description: 'Do not lock issues with these labels, value must be a comma separated list of labels'
     default: ''
@@ -28,6 +31,9 @@ inputs:
     default: '365'
   pr-exclude-created-before:
     description: 'Do not lock pull requests created before a given timestamp, value must follow ISO 8601'
+    default: ''
+  pr-include-labels:
+    description: 'Only lock pull requests with these labels, value must be a comma separated list of labels'
     default: ''
   pr-exclude-labels:
     description: 'Do not lock pull requests with these labels, value must be a comma separated list of labels'

--- a/src/index.js
+++ b/src/index.js
@@ -89,6 +89,14 @@ class App {
     );
     let query = `repo:${owner}/${repo} updated:<${timestamp} is:closed is:unlocked`;
 
+    const includeLabels = this.config[type + 'IncludeLabels'];
+    if (includeLabels) {
+      const queryPart = includeLabels
+        .map(label => `label:"${label}"`)
+        .join(' ');
+      query += ` ${queryPart}`;
+    }
+
     const excludeLabels = this.config[type + 'ExcludeLabels'];
     if (excludeLabels) {
       const queryPart = excludeLabels

--- a/src/schema.js
+++ b/src/schema.js
@@ -56,6 +56,24 @@ const schema = Joi.object({
     )
     .default(''),
 
+  issueIncludeLabels: Joi.alternatives()
+    .try(
+      extendedJoi
+        .stringList()
+        .items(
+          Joi.string()
+            .trim()
+            .max(50)
+        )
+        .min(1)
+        .max(30)
+        .unique(),
+      Joi.string()
+        .trim()
+        .valid('')
+    )
+    .default(''),
+
   issueExcludeLabels: Joi.alternatives()
     .try(
       extendedJoi
@@ -114,6 +132,24 @@ const schema = Joi.object({
         // .iso()
         .min('1970-01-01T00:00:00Z')
         .max('2970-12-31T23:59:59Z'),
+      Joi.string()
+        .trim()
+        .valid('')
+    )
+    .default(''),
+
+  prIncludeLabels: Joi.alternatives()
+    .try(
+      extendedJoi
+        .stringList()
+        .items(
+          Joi.string()
+            .trim()
+            .max(50)
+        )
+        .min(1)
+        .max(30)
+        .unique(),
       Joi.string()
         .trim()
         .valid('')


### PR DESCRIPTION
Hi, this PR is adding support for only including specified labels. It is intended to be used as such:
```yaml
    steps:
      - uses: dessant/lock-threads
        with:
          github-token: ${{ github.token }}
          issue-include-labels: 'invalid'
          issue-lock-inactive-days: 0  # lock invalid issues quickly than other labels
          process-only: 'issues'
      - uses: dessant/lock-threads
        with:
          github-token: ${{ github.token }}
          issue-lock-inactive-days: 30  # usual period for issues
          process-only: 'issues'
```
Note that the code is untested as it is unclear for me of how to run it.