### PR TITLE
add ability to lock open threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ The action can be configured using [input parameters](https://docs.github.com/en
   - Labels to remove before locking an issue, value must be
     a comma separated list of labels or `''`
   - Optional, defaults to `''`
+- **`include-issue-currently-open`**
+  - Open issues are also eligible to be locked.
+  - Optional, defaults to `false`
 - **`issue-comment`**
   - Comment to post before locking an issue
   - Optional, defaults to `''`
@@ -139,6 +142,9 @@ The action can be configured using [input parameters](https://docs.github.com/en
   - Labels to remove before locking a pull request, value must be
     a comma separated list of labels or `''`
   - Optional, defaults to `''`
+- **`include-pr-currently-open`**
+  - Open pull requests are also eligible to be locked.
+  - Optional, defaults to `false`
 - **`pr-comment`**
   - Comment to post before locking a pull request
   - Optional, defaults to `''`
@@ -198,6 +204,11 @@ The action can be configured using [input parameters](https://docs.github.com/en
   - Labels to remove before locking a discussion, value must be
     a comma separated list of labels or `''`
   - Optional, defaults to `''`
+- **`include-discussion-currently-open`**
+  - Open discussions are also eligible to be locked. Useful 
+    for projects that do not use the open/close state on 
+    discussions.
+  - Optional, defaults to `false`
 - **`discussion-comment`**
   - Comment to post before locking a discussion
   - Optional, defaults to `''`
@@ -308,6 +319,7 @@ jobs:
           exclude-any-issue-labels: ''
           add-issue-labels: ''
           remove-issue-labels: ''
+          include-issue-currently-open: false
           issue-comment: ''
           issue-lock-reason: 'resolved'
           pr-inactive-days: '365'
@@ -322,6 +334,7 @@ jobs:
           exclude-any-pr-labels: ''
           add-pr-labels: ''
           remove-pr-labels: ''
+          include-pr-currently-open: false
           pr-comment: ''
           pr-lock-reason: 'resolved'
           discussion-inactive-days: '365'
@@ -336,6 +349,7 @@ jobs:
           exclude-any-discussion-labels: ''
           add-discussion-labels: ''
           remove-discussion-labels: ''
+          include-discussion-currently-open: false
           discussion-comment: ''
           process-only: ''
           log-output: false

--- a/action.yml
+++ b/action.yml
@@ -41,6 +41,9 @@ inputs:
   remove-issue-labels:
     description: 'Labels to remove before locking an issue, value must be a comma separated list of labels'
     default: ''
+  include-issue-currently-open:
+    description: 'Open issues are also eligible to be locked'
+    default: false
   issue-comment:
     description: 'Comment to post before locking an issue'
     default: ''
@@ -83,6 +86,9 @@ inputs:
   remove-pr-labels:
     description: 'Labels to remove before locking a pull request, value must be a comma separated list of labels'
     default: ''
+  include-pr-currently-open:
+    description: 'Open pull requests are also eligible to be locked'
+    default: false
   pr-comment:
     description: 'Comment to post before locking a pull request'
     default: ''
@@ -125,6 +131,9 @@ inputs:
   remove-discussion-labels:
     description: 'Labels to remove before locking a discussion, value must be a comma separated list of labels'
     default: ''
+  include-discussion-currently-open:
+    description: 'Open discussions are also eligible to be locked'
+    default: false
   discussion-comment:
     description: 'Comment to post before locking a discussion'
     default: ''

--- a/src/index.js
+++ b/src/index.js
@@ -216,7 +216,12 @@ class App {
     const updatedTime = this.getUpdatedTimestamp(
       this.config[`${threadType}-inactive-days`]
     );
-    let query = `repo:${owner}/${repo} updated:<${updatedTime} is:closed is:unlocked`;
+    let query = `repo:${owner}/${repo} updated:<${updatedTime} is:unlocked`;
+
+    const includeOpen = this.config[`include-${threadType}-currently-open`];
+    if (!includeOpen) {
+      query += ' is:closed';
+    }
 
     const includeAnyLabels = this.config[`include-any-${threadType}-labels`];
     const includeAllLabels = this.config[`include-all-${threadType}-labels`];

--- a/src/schema.js
+++ b/src/schema.js
@@ -143,6 +143,8 @@ const schema = Joi.object({
 
   'remove-issue-labels': joiLabels.default(''),
 
+  'include-issue-currently-open': Joi.boolean().default(false),
+
   'issue-comment': Joi.string().trim().max(10000).allow('').default(''),
 
   'issue-lock-reason': Joi.string()
@@ -172,6 +174,8 @@ const schema = Joi.object({
   'add-pr-labels': joiLabels.default(''),
 
   'remove-pr-labels': joiLabels.default(''),
+
+  'include-pr-currently-open': Joi.boolean().default(false),
 
   'pr-comment': Joi.string().trim().max(10000).allow('').default(''),
 
@@ -206,6 +210,8 @@ const schema = Joi.object({
   'add-discussion-labels': joiLabels.default(''),
 
   'remove-discussion-labels': joiLabels.default(''),
+
+  'include-discussion-currently-open': Joi.boolean().default(false),
 
   'discussion-comment': Joi.string().trim().max(10000).allow('').default(''),
 


### PR DESCRIPTION
This PR addresses #45 by introducing three new optional parameters:

- `include-issue-currently-open` (default: `false`)
- `include-pr-currently-open` (default: `false`)
- `include-discussion-currently-open` (default: `false`)

I do not _close_ discussions on my projects, and some discussions are not answerable. But I also do not want very old discussions to be commented upon. This PR provides the ability to auto lock those old, open discussions. For consistency, the issues and PRs are also capable of supporting this.

I have this actively running on my two of my projects so far and it's working well. Example workflow:

```
name: 'Lock Threads'

on:
  schedule:
    - cron: '50 1 * * *'
  workflow_dispatch:

permissions:
  issues: write
  pull-requests: write
  discussions: write

concurrency:
  group: lock-threads

jobs:
  lock-threads:
    runs-on: ubuntu-latest
    steps:
      - uses: jertel/lock-threads@main
        with:
          include-discussion-currently-open: true
          discussion-inactive-days: 90
          issue-inactive-days: 30
          pr-inactive-days: 30
```

Feel free to close this if you prefer keeping the project to only work on closed threads.

Thanks for starting this project!